### PR TITLE
Fix ARCHIVES.gz URL for Leap

### DIFF
--- a/zyp-file.sh
+++ b/zyp-file.sh
@@ -81,7 +81,7 @@ case "$action" in
 		dir=$(dirname "$userarch")
 		mkdir -p "$dir"
 		cd "$dir"
-		wget -N "http://download.opensuse.org/distribution/$VERSION_ID/repo/oss/ARCHIVES.gz"
+		wget -N "http://download.opensuse.org/distribution/leap/$VERSION_ID/repo/oss/ARCHIVES.gz"
 		;;
 	search | show)
 		if [ -z "$arch" ]; then


### PR DESCRIPTION
This changed when openSUSE Leap XX.X replaced openSUSE XX.X as a release name.